### PR TITLE
feat: added optional `urlPrefixes` to the plugin options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -62,6 +62,12 @@ export interface ViteAppsignalOptions {
    * @default '~/'
    */
   urlPrefix?: string
+
+  /**
+   * List of URL prefixes to add to the beginning of all filenames, cloud be used instead of a single `urlPrefix`.
+   * Defaults to an array with a `urlPrefix` as single entry.
+   */
+  urlPrefixes?: string[]
 }
 
 /**


### PR DESCRIPTION
Hi, I liked to upload sourcemaps, which live on different domains, like: `https://my-app.com`, `https://stage.my-app.com`, `http://localhost:4173`, ...

So I added an optional setting `urlPrefixes`:
```
const appsignalConfig: ViteAppsignalPluginOptions = {
  ...
  // urlPrefix: 'https://my-app.com/assets',
  urlPrefixes: ['https://my-app.com/assets/', 'https://stage.my-app.com/assets/', 'http://localhost:4173/assets/'],
}
```

This resolves into an array of URLs, which hits the API of AppSignal, where the `name[]` parameter already consumes a list of names. (see https://docs.appsignal.com/api/sourcemaps.html#parameters).

I hope this PR is fine for you @pantajoe :)